### PR TITLE
Use JoliTypo "fix" instead of "fixString"

### DIFF
--- a/typographe.php
+++ b/typographe.php
@@ -46,7 +46,7 @@ class plgSystemTypographe  extends JPlugin
 		
 		$fixer = new Fixer($parametres);	
 		$fixer->setLocale($this->params->get('setlocale','fr_FR'));
-		$article->text = $fixer->fixString($article->text); 
+		$article->text = $fixer->fix($article->text); 
 		
 	}
 


### PR DESCRIPTION
Using "fix" allow JoliTypo to be aware of HTML context, and then apply the fix only when needed.

The "fixString" method can only be used on pure string without DOM content.

I got feedback from users having some `<script>` in their content that was broken by JoliTypo.

I did not test and cannot try it sorry.